### PR TITLE
add CentOS 7 support

### DIFF
--- a/tasks/config_webserver.yml
+++ b/tasks/config_webserver.yml
@@ -1,3 +1,14 @@
+- name: Create httpd config directories for CentOS
+  file:
+    path: "{{httpd_conf_directory}}/{{ item }}/"
+    state: directory
+    owner: "{{ matomo_user }}"
+    group: "{{ matomo_user }}"
+    mode: "urwx,gr,o-rwx"
+  with_items:
+    - "conf-available"
+    - "conf-enabled"
+  when: ansible_os_family == "RedHat"
 
 - name: Install matomo httpd config file
   template:


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW/issues/946

# What does this Pull Request do?

Creates the Ubuntu Apache conf directories in CentOs so playbooks that expect them won't crash.

# What's new?

A new task restricted to RedHat/CentOS hosts that creates conf-available and conf-enabled in httpd.

# How should this be tested?

- `export ISLANDORA_DISTRO="centos/7"`
- update your playbook requirements.yml to target https://github.com/seth-shaw-unlv/ansible-role-matomo instead of https://github.com/Islandora-Devops/ansible-role-matomo and remove the version tag
- `vagrant up --provision`
- Check that localhost:8000/matomo works.

Matomo should install on CentOS.

# Interested parties
@Natkeeran, @Islandora-CLAW/committers