### PR TITLE
Adds support for using a remote database.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,15 +11,18 @@ console_install: true
 # Database
 matomo_db: mysql
 matomo_pgsql_user: postgres
+matomo_db_root_user:  "{% if matomo_db == 'mysql' %}root{% elif matomo_db == 'pgsql' %}{{ matomo_pgsql_user }}{% endif %}" 
+matomo_db_root_password: "" 
 matomo_db_user: matomo
 matomo_db_password: islandora
 matomo_db_name: matomo
 matomo_db_driver: "{% if matomo_db == 'mysql' %}pdo_mysql{% elif matomo_db == 'pgsql' %}pdo_pgsql{% endif %}"
 matomo_db_port: "{% if matomo_db == 'mysql' %}3306{% elif matomo_db == 'pgsql' %}5432{% endif %}"
+matomo_db_host: 127.0.0.1 
 
 matomo_db_options:
   driver: "{{ matomo_db_driver }}"
-  host: 127.0.0.1
+  host: "{{ matomo_db_host }}"
   port: "{{ matomo_db_port }}"
   dbname: "{{ matomo_db_name }}"
   user: "{{ matomo_db_user }}"

--- a/tasks/console_install.yml
+++ b/tasks/console_install.yml
@@ -14,6 +14,10 @@
     name: "{{ matomo_db_name }}"
     target: "{{ webserver_document_root }}/matomo.sql"
     state: import
+    login_host: "{{ matomo_db_host }}"
+    login_port: "{{ matomo_db_port }}"
+    login_user: "{{ matomo_db_root_user }}"
+    login_password:  "{{ matomo_db_root_password }}"
   ignore_errors: yes
   when: motomo_sql_dump_create | changed
 

--- a/tasks/db-mysql.yml
+++ b/tasks/db-mysql.yml
@@ -3,6 +3,10 @@
 - name: Create Matomo DB (mysql)
   mysql_db:
     name: "{{ matomo_db_name }}"
+    login_host: "{{ matomo_db_host }}"
+    login_port: "{{ matomo_db_port }}"
+    login_user: "{{ matomo_db_root_user }}"
+    login_password:  "{{ matomo_db_root_password }}"
     state: present
   register: matomo_db_exists
 
@@ -10,5 +14,10 @@
   mysql_user:
     name: "{{ matomo_db_user }}"
     password: "{{ matomo_db_password }}"
+    login_host: "{{ matomo_db_host }}"
+    login_port: "{{ matomo_db_port }}"
+    login_user: "{{ matomo_db_root_user }}"
+    login_password:  "{{ matomo_db_root_password }}"
+    host: "%"
     state: present
     priv: "{{matomo_db_name}}.*:ALL"

--- a/tasks/db-pgsql.yml
+++ b/tasks/db-pgsql.yml
@@ -6,6 +6,10 @@
   postgresql_user:
     name: "{{ matomo_db_user }}"
     password: "{{ matomo_db_password }}"
+    login_host: "{{ matomo_db_host }}"
+    login_port: "{{ matomo_db_port }}"
+    login_user: "{{ matomo_db_root_user }}"
+    login_password:  "{{ matomo_db_root_password }}"
 
 - name: Create Matomo DB (pgsql)
   become: yes
@@ -14,6 +18,10 @@
     name: "{{ matomo_db_name }}"
     state: present
     owner: "{{ matomo_db_user }}"
+    login_host: "{{ matomo_db_host }}"
+    login_port: "{{ matomo_db_port }}"
+    login_user: "{{ matomo_db_root_user }}"
+    login_password:  "{{ matomo_db_root_password }}"
   register: matomo_db_exists
 
 


### PR DESCRIPTION
**GitHub Issue**: N/A

* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

It allows the matomo database to live on a non-local database server.

# What's new?
The parameters that allow for remote database creation and connection.
# How should this be tested?
Set up a remote database server and specify the necessary parameter overrides.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Devops/committers
