### PR TITLE
Fix test syntax

### DIFF
--- a/tasks/console_install.yml
+++ b/tasks/console_install.yml
@@ -15,7 +15,7 @@
     target: "{{ webserver_document_root }}/matomo.sql"
     state: import
   ignore_errors: yes
-  when: motomo_sql_dump_create | changed
+  when: motomo_sql_dump_create is changed
 
 # create config.ini.php with default settings
 - name: Create config.ini.php


### PR DESCRIPTION
According to https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html#test-syntax
The correct form form tests is as suggested; the old way of using filter syntax produces error in Ansible 2.9 (at least).


* Other Relevant Links (Google Groups discussion, related pull requests,
 Release pull requests, etc.)

# What does this Pull Request do?

The modified line caused an error when runnign the playbook with Ansible 2.9. The proposed change fixes the error by using correct test format as suggested by Ansible documentation

# What's new?

Replace `| changed` with `is changed` in a when test.

# Issue

Fixes issue #7 

# How should this be tested?

By running the old and new versions with ansible-playbook. The old version fails with 

"The conditional check 'motomo_sql_dump_create | changed' failed. The error was: template error while templating string: no filter named 'changed'. String: {% if motomo_sql_dump_create | changed %} True {% else %} False {% endif %}\n\nThe error appears to be in '/home/user/directory/islandora-playbook/roles/external/Islandora-Devops.matomo/tasks/console_install.yml': line 12, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: restore dump\n  ^ here\n"

# Interested parties
@Islandora-Devops/committers
